### PR TITLE
ValueFilterIgnoreTransform

### DIFF
--- a/contrib/niwa/logger/transforms/value_filter_ignore_transform.py
+++ b/contrib/niwa/logger/transforms/value_filter_ignore_transform.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+
+from os.path import dirname, realpath
+sys.path.append(dirname(dirname(dirname(realpath(__file__)))))
+from logger.utils.das_record import DASRecord  # noqa: E402
+from logger.transforms.transform import Transform  # noqa: E402
+
+
+################################################################################
+#
+class ValueFilterIgnoreTransform(Transform):
+    """
+    Transform that filters out DASRecords where values are out of bounds. 
+    Differs from ValueFilterTransform in that it allows string matches using the exact_match flag
+    and it doesn't remove the value from the DASRecord just prevents any further transforms or writers running. 
+    It also only sends 1 log when this first happens rather than every time"""
+
+    def __init__(self, bounds, exact_match=None, log_level=logging.INFO):
+        """
+        ```
+        bounds
+                 A comma-separated list of conditions of the format
+
+                    <field_name>:<lower_bound>:<upper_bound>
+
+                 Either <lower_bound> or <upper_bound> may be empty. For example:
+                    # No lower temp, no upper speed
+                    'SeawaterTemp::50,SpeedOverGround:0:,CourseOverGround:0:360'
+
+        log_level
+                 At what level the transform should log a message when it sees a value
+                 that is out of bounds. Allowed values are log levels from the logging module,
+                 e.g. logging.INFO, logging.DEBUG, logging.WARNING, etc.
+
+                 If the logger is running in normal mode, it will display messages that
+                 have log level INFO and more severe (WARNING, ERROR, FATAL). Setting the
+                 log_level parameter of this transform to logging.WARNING means that any time
+                 a value falls out of its specified bounds, a WARNING message will be sent to
+                 the console, appearing in yellow on the web console. logging.ERROR means it will
+                 appear in red. Setting it to logging.DEBUG means that no message will appear on
+                 the console.
+
+        ```
+        """
+        self.bounds = {}
+        self.exact_match = exact_match
+        
+        for condition in bounds.split(','):
+            if self.exact_match:
+                try:
+                    (var, match) = condition.split(':')
+                    self.bounds[var] = match
+                except ValueError:
+                    raise ValueError('ValueFilterTransform bounds for exact match must be colon-separated '
+                                    'double of field_name:matching. '
+                                    f'Found "{condition}" instead.')
+            else:
+                try:
+                    (var, lower_str, upper_str) = condition.split(':')
+                    lower = None if lower_str == '' else float(lower_str)
+                    upper = None if upper_str == '' else float(upper_str)
+                    self.bounds[var] = (lower, upper)
+                except ValueError:
+                    raise ValueError('ValueFilterTransform bounds must be colon-separated '
+                                    'triples of field_name:lower_bound:upper_bound. '
+                                    f'Found "{condition}" instead.')
+        if log_level not in [logging.DEBUG, logging.INFO, logging.WARNING,
+                             logging.ERROR, logging.FATAL]:
+            raise ValueError('ValueFilterTransform log_level must be a logging module log '
+                             'level, such as logging.DEBUG, logging.INFO or logging.WARNING. '
+                             f'Found "{log_level}" instead.')
+        self.log_level = log_level
+        
+        self.has_filtered = False
+
+    ############################
+    def transform(self, record):
+        """Does record violate any bounds?"""
+        if not record:
+            return None
+
+        # If we've got a list, hope it's a list of records. Recurse,
+        # calling transform() on each of the list elements in order and
+        # return the resulting list.
+        if type(record) is list:
+            results = []
+            for single_record in record:
+                results.append(self.transform(single_record))
+            return results
+
+        if type(record) is DASRecord:
+            fields = record.fields
+        elif type(record) is dict:
+            if 'fields' in record:
+                fields = record['fields']
+            else:
+                fields = record
+        else:
+            logging.log(self.log_level,
+                        f'Record passed to ValueFilterTransform was neither a dict nor a '
+                        f'DASRecord. Type was {type(record)}: {str(record)[:80]}')
+
+            return None
+
+        for bound in self.bounds:
+            if bound not in fields:
+                continue
+
+            value = fields.get(bound)  # what is the record's value of this field?
+
+            if self.exact_match:
+                if value != self.bounds[bound]:
+                    return None
+            else:
+                (lower, upper) = self.bounds[bound]  # what are the upper/lower bounds?
+                # We expect field value to be numeric; if not, try to convert
+                if type(value) is not int and type(value) is not float:
+                    try:
+                        value = float(value)
+                    except:
+                        logging.log(self.log_level,
+                                    'ValueFilterTransform found non-numeric value for {bound}: {value}')
+
+                        if not self.has_filtered:
+                            logging.log(logging.WARNING, f"This logger is filtering out records with non-numeric values for {bound}: {value}")
+                            self.has_filtered = True
+                        return None
+
+                # If value exists and is out of bounds, ignore it
+                if lower is not None and value < lower:
+                    logging.log(self.log_level,
+                                f'Value for {bound}: {value} less than lower bound {lower}')
+                    if not self.has_filtered:
+                            previous_level = logging.root.level
+                            logging.root.setLevel(logging.INFO)
+                            logging.log(logging.WARNING, f"This logger is filtering out records with values for {bound} less than {lower}")
+                            logging.root.setLevel(previous_level)
+                            self.has_filtered = True
+                    return None
+                elif upper is not None and value > upper:
+                    logging.log(self.log_level,
+                                f'Value for {bound}: {value} greater than upper bound {upper}')
+                    if not self.has_filtered:
+                            previous_level = logging.root.level
+                            logging.root.setLevel(logging.INFO)
+                            logging.log(logging.WARNING, f"This logger is filtering out records with values for {bound} greater than {upper}")
+                            logging.root.setLevel(previous_level)
+                            self.has_filtered = True
+                    return None
+
+        return record

--- a/contrib/niwa/test/test_value_filter_ignore_transform.py
+++ b/contrib/niwa/test/test_value_filter_ignore_transform.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import logging
+import sys
+import unittest
+
+from logger.utils.das_record import DASRecord
+
+sys.path.append('.')
+from contrib.niwa.logger.transforms.value_filter_ignore_transform import ValueFilterIgnoreTransform  # noqa: E402
+from logger.transforms.parse_transform import ParseTransform  # noqa: E402
+
+# flake8: noqa E501  - don't worry about long lines in sample data
+
+LINES = """grv1 2017-11-04T05:12:21.018622Z 01:025876 00
+grv1 2017-11-04T05:12:21.273413Z 01:022013 00
+grv1 2017-11-04T05:12:21.528747Z 01:021077 00
+grv1 2017-11-04T05:12:21.784089Z 01:023624 00
+grv1 2017-11-04T05:12:22.034195Z 01:027210 00
+grv1 2017-11-04T05:12:22.285414Z 01:029279 00
+grv1 2017-11-04T05:12:22.538658Z 01:028207 00
+grv1 2017-11-04T05:12:22.794031Z 01:024334 00
+grv1 2017-11-04T05:12:23.044427Z 01:020168 00
+grv1 2017-11-04T05:12:23.298491Z 01:019470 00""".split('\n')
+
+
+class TestValueFilterIgnoreTransform(unittest.TestCase):
+
+    ############################
+    def test_default(self):
+        p = ParseTransform(field_patterns=['{Units:d}:{GravValue:d} {GravError:d}'])
+        q = ValueFilterIgnoreTransform(bounds='GravValue:22000:23000,GravError::2')
+
+        record = p.transform('grv1 2017-11-04T05:12:21.273413Z 01:022013 00')
+        self.assertEqual(q.transform(record), record)
+
+        record = p.transform('grv1 2017-11-04T05:12:21.273413Z 01:022013 -5')
+        self.assertEqual(q.transform(record), record)
+
+        # bad value
+        record = p.transform('grv1 2017-11-04T05:12:21.273413Z 01:023013 00')
+        self.assertIsNone(q.transform(record))
+        
+        # two bad values
+        record = p.transform('grv1 2017-11-04T05:12:21.273413Z 01:023013 03')
+        self.assertIsNone(q.transform(record))
+
+    def test_negative_value(self):
+        p = ParseTransform(field_patterns=['{Units:d}:{GravValue:d} {GravError:d}'])
+        q = ValueFilterIgnoreTransform(bounds='GravValue:0.01:')
+
+        record = DASRecord(data_id="grv1", timestamp="2017-11-04T05:12:21.273413Z", fields={
+            "Units": "01",
+            "GravValue": "0.02",
+            "GravError": "00"
+        })
+        self.assertEqual(q.transform(record), record)
+
+        # bad value
+        record = DASRecord(data_id="grv1", timestamp="2017-11-04T05:12:21.273413Z", fields={
+            "Units": "01",
+            "GravValue": "-0.4",
+            "GravError": "00"
+        })
+        self.assertIsNone(q.transform(record))
+        
+
+    ############################
+    def test_error(self):
+        p = ParseTransform(
+            field_patterns=['{LF:nc},{LFDepth:of},{LFValid:od},{HF:nc},{HFDepth:of},{HFValid:od},{SoundSpeed:og},{Latitude:f},{Longitude:f}'])
+        q = ValueFilterIgnoreTransform(bounds='LFDepth:0:6000,HFDepth:0:5000', log_level=logging.INFO)
+        with self.assertLogs(level='INFO') as cm:
+            test_str = 'knud 2017-11-04T05:12:21.981359Z 3.5kHz,5146.29,0,,,,1500,-39.583558,-37.466183'
+            record = p.transform(test_str)
+            self.assertIsNone(q.transform(record))
+
+        q = ValueFilterIgnoreTransform(bounds='LFDepth:0:6000,HFDepth:0:5000', log_level=logging.WARNING)
+        with self.assertLogs(level='WARNING') as cm:
+            test_str = 'knud 2017-11-04T05:12:21.981359Z 3.5kHz,5146.29,0,,,,1500,-39.583558,-37.466183'
+            record = p.transform(test_str)
+            self.assertIsNone(q.transform(record))
+
+        with self.assertLogs(level='WARNING') as cm:
+            record = 'knud 2017-11-04T05:12:21.981359Z'
+            self.assertEqual(q.transform(record), None)
+            self.assertEqual(cm.output,
+                             ['WARNING:root:Record passed to ValueFilterTransform was neither a dict nor a '
+                              "DASRecord. Type was <class 'str'>: knud 2017-11-04T05:12:21.981359Z"])
+
+        with self.assertRaises(ValueError):
+            ValueFilterIgnoreTransform(bounds='LFDepth:0:6000,HFDepth:0:5000', log_level='a string')
+
+
+    def test_exact_match(self):
+        p = ParseTransform(field_patterns=['{Units:d}:{GravValue:d} {GravError:d}'])
+        q = ValueFilterIgnoreTransform(bounds='GravError:CC', exact_match=True)
+
+        record = DASRecord(data_id="grv1", timestamp="2017-11-04T05:12:21.273413Z", fields={
+            "Units": "01",
+            "GravValue": "0.02",
+            "GravError": "CC"
+        })
+        self.assertEqual(q.transform(record), record)
+
+        # bad value
+        record = DASRecord(data_id="grv1", timestamp="2017-11-04T05:12:21.273413Z", fields={
+            "Units": "01",
+            "GravValue": "-0.4",
+            "GravError": "DD"
+        })
+        self.assertIsNone(q.transform(record))
+
+
+    ############################
+
+    def test_message(self):
+        q = ValueFilterIgnoreTransform(bounds='LFDepth:0:6000,HFDepth:0:5000')
+        record = {'LFDepth': 5999}
+        self.assertEqual(q.transform(record), record)
+
+        record = {'LFDepth': 6001}
+        self.assertIsNone(q.transform(record))
+
+
+################################################################################
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbosity', dest='verbosity',
+                        default=0, action='count',
+                        help='Increase output verbosity')
+    args = parser.parse_args()
+
+    LOGGING_FORMAT = '%(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+    logging.basicConfig(format=LOGGING_FORMAT)
+
+    LOG_LEVELS = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
+    args.verbosity = min(args.verbosity, max(LOG_LEVELS))
+    logging.getLogger().setLevel(LOG_LEVELS[args.verbosity])
+
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
Altered version of the `ValueFilterTransform`. This version:
- Allows string matches using the exact_match flag
- Doesn't remove the value from the DASRecord just prevents any further transforms or writers running. 
- Only sends 1 log when this first happens rather than every time a value is filtered

I use it for avoiding writing pointless data to the database such as the winch logger (where the UDPUnparsedWriter below sends records to the database writer)

```yaml
writers:
  - class: ComposedWriter
    kwargs:
      transforms:
      - class: TimestampTransform
      - class: PrefixTransform
        kwargs:
          prefix: Winch
      writers:
      - class: ComposedWriter
        kwargs:
          transforms:
          - class: RegexParseTransform
            kwargs:
              definition_path: local/niwa/device_types/*.yaml,local/niwa/devices/Winch.yaml
              metadata_interval: 10
            module: contrib.niwa.logger.transforms.regex_parse_transform
          - class: ValueFilterIgnoreTransform
            kwargs:
              bounds: 'WinchPaidOutWire:0.01:,WinchTension:0.01:'
            module: contrib.niwa.logger.transforms.value_filter_ignore_transform
          writers:
          - class: CachedDataWriter
            kwargs:
              data_server: localhost:8766
          - class: UDPUnparsedWriter
            kwargs:
              destination: localhost
              port: 6224
            module: contrib.niwa.logger.writers.udp_unparsed_writer
```